### PR TITLE
Disabled text selection for all buttons

### DIFF
--- a/base-styles.css
+++ b/base-styles.css
@@ -1,0 +1,23 @@
+/*
+This file contains the base styles used for the calculator.
+To add your own theme, see the README.md 
+*/
+
+
+/* Disable selection for everything */
+*
+{
+  user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+}
+
+/* Allow selection for result container */
+#calculator .result span
+{
+  user-select: auto;
+  -webkit-user-select: auto;
+  -moz-user-select: auto;
+  -ms-user-select: auto;
+}

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>Calculator</title>
+  <link rel="stylesheet" href="base-styles.css">
   <link class="styles" rel="stylesheet" href="css/index.css">
   <script
   src="https://code.jquery.com/jquery-3.2.1.min.js"></script>


### PR DESCRIPTION
By default, every button's text could be selected like normal text.
To diable this behaviour, I added the CSS option user-select to all elements
except the result container so the user is still able to select the calculated answer.

If any other CSS rules need to be applied gloablly, they can be added to the newly
created base-styles.css file.